### PR TITLE
Swapped cairo dependency in export_svg to svgwrite

### DIFF
--- a/svg-sorter.py
+++ b/svg-sorter.py
@@ -30,6 +30,27 @@ def export_svg(fn, paths, w, h, line_width=0.1):
 
   c.save()
 
+def export_svg_svgwrite(fn, paths, w, h, line_width=0.1):
+
+  from svgwrite import Drawing
+  w_str = "{}pt".format(w)
+  h_str = "{}pt".format(h)
+
+  dwg = Drawing(filename = fn,
+                size = (w_str, h_str),
+                viewBox=("0 0 {} {}".format(w,h)))
+
+  for path in paths:
+    if(len(path) > 1):
+      str_list = []
+      str_list.append("M {},{}".format(path[0,0],path[0,1]))
+      for e in path[1:]:
+        str_list.append(" L {},{}".format(e[0],e[1]))
+      s = ''.join(str_list)
+      dwg.add(dwg.path(s).stroke(color="rgb(0%,0%,0%)",width=line_width).fill("none"))
+
+  dwg.save()
+
 def get_mid(v):
 
   from numpy import array
@@ -184,7 +205,11 @@ def main(args, **argv):
   paths = align_left(paths, mi)
 
   w, h = ma - mi
-  export_svg(out, paths, w, h, line_width=1)
+  if args.svgwrite:
+    export_svg_svgwrite(out, paths, w, h, line_width=1)
+  else:
+    export_svg(out, paths, w, h, line_width=1)
+
   # return
 
 if __name__ == '__main__':
@@ -201,6 +226,13 @@ if __name__ == '__main__':
     '--out',
     type=str,
     required=True
+  )
+  parser.add_argument(
+    '--svgwrite',
+    default=False,
+    action='store_true',
+    help="Disable cairo and use svgwrite instead.",
+    required=False
   )
 
   args = parser.parse_args()


### PR DESCRIPTION
OK, first the bad news. This is slow. Like maybe 10-20x slow. Why? I think cairo was doing all the float to string conversions natively, and now they are happening in python. If so, I don't think there isn't a way around this. Secondly - this isn't as battle tested as I only tried it on the included test png.

And the good news? Well obviously we get to drop a big nasty `cairo` dependency. But also for me when previewing with chrome, the cairo code was adding a handful of subtle visual artifacts into the converted svg, which the new svgwrite code doesn't do. Here's a couple of examples:

| original | cairo | svgwrite |
| --- | --- | --- |
| ![original](https://cloud.githubusercontent.com/assets/945979/17174717/8e94a5da-5457-11e6-9106-e8babe15e3ed.png) | ![old](https://cloud.githubusercontent.com/assets/945979/17174772/e74573e4-5457-11e6-9f6f-0f5d19dbf291.png) | ![new](https://cloud.githubusercontent.com/assets/945979/17174715/8e50900c-5457-11e6-9867-1b2ea444aa3f.png) |
| ![original](https://cloud.githubusercontent.com/assets/945979/17175030/69888e76-5459-11e6-84a4-8b6e8ac471ff.png) | ![old](https://cloud.githubusercontent.com/assets/945979/17175028/698363f6-5459-11e6-92f3-8527ac881968.png) | ![new](https://cloud.githubusercontent.com/assets/945979/17175029/69866470-5459-11e6-8470-93d2ef1a67cf.png) |

You can see these in the existing `data/res.svg` file in this repo, and I confirmed I get the same on fresh runs as well. Very possible that this is just a linecap setting or something similar that doesn't matter for a plotter use case, but it's worth pointing out.

So not sure what to do. If it were up to me, I might keep both and add a command line switch to invoke the second version. If you'd like me to add a commit for that let me know.
